### PR TITLE
Force sugar-runner.desktop to use Terminal

### DIFF
--- a/data/sugar-runner.desktop
+++ b/data/sugar-runner.desktop
@@ -4,3 +4,4 @@ Name=Sugar
 Exec=sugar-runner
 Icon=sugar-xo
 Categories=Education;X-Teaching;
+Terminal=true


### PR DESCRIPTION
This is related to #4 

sugar-runner fails on Run Command because it cannot be executed along with `nohup`. However, keeping a running terminal open allows to run sugar-runner. This might be caused due to the incompatibility of the Xephyr and other `X` libs to create nohup background processes. Most Run commands use nohup to start the process. However, as an alternative, the sugar-runner.desktop can be fixed to allow the running from the GUI icon