### PR TITLE
Make sugar-runner work with Python 3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ m4
 *.lo
 libtool
 sugar-runner
+/compile

--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sugar-runner</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,1 @@
+Make sugar-runner work with Python 3. (James Simmons)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Sugar Runner should not be used with naive learners, as they may escape from Sug
 
 Sugar Runner should not be used by testers, as the testing will miss critical aspects of the session interaction, such as shutdown and restart.
 
+At this time sugar-runner *only* works with Xorg, NOT Wayland. In Fedora there is a gear symbol on the login page 
+which lets you choose to run GNOME or GNOME Classic on Xorg. If you choose one of these options before logging in
+sugar-runner should work for you.
+
 # How It Works
 
 * unsets variables inherited from the existing session,
@@ -31,6 +35,8 @@ sudo make install
 
 ## You will need to install Xephyr:
 
+in Fedora:
+
 sudo dnf install Xephyr
 
 ## Set up some environment variables:
@@ -42,5 +48,3 @@ export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ## Then run:
 
 sugar-runner
-
-At this time all that will happen is Xephyr tries to open and fails.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,27 @@ Sugar Runner should not be used by testers, as the testing will miss critical as
 * substitutes an alternate home directory for XDG data,
 * turns off the Sugar shutdown and restart options,
 * forks Xvfb with Xephyr.
+
+# How To Build And Test
+
+./autogen.sh
+
+make
+
+sudo make install
+
+## You will need to install Xephyr:
+
+sudo dnf install Xephyr
+
+## Set up some environment variables:
+
+export GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+## Then run:
+
+sugar-runner
+
+At this time all that will happen is Xephyr tries to open and fails.

--- a/scripts/sugar-runner.in
+++ b/scripts/sugar-runner.in
@@ -1,5 +1,4 @@
-#!/usr/bin/python2 -u
-
+#!/usr/bin/python3 -u
 # Copyright (C) 2013, Daniel Narvaez
 #
 # This program is free software; you can redistribute it and/or modify
@@ -60,13 +59,13 @@ def _write_xkb_config():
 
 def _allow_to_run_x():
     try:
-        with open("/etc/X11/Xwrapper.config") as f:
+        with open("/etc/X11/Xwrapper.config", 'rb') as f:
             if "allowed_users=anybody" in f.read():
                 return
     except IOError:
         return
 
-    print "We need to allow everybody to run the X server"
+    print("We need to allow everybody to run the X server")
     tweak_wrapper = os.path.join(helpers_dir, "tweak-xwrapper")
     subprocess.check_call(["sudo", "-k", tweak_wrapper])
 
@@ -96,10 +95,10 @@ def _setup_keyring():
         except OSError:
             pass
 
-        with open(os.path.join(keyrings_dir, "default"), "w") as f:
+        with open(os.path.join(keyrings_dir, "default"), "wb") as f:
             f.write("default")
 
-        with open(os.path.join(keyrings_dir, "default.keyring"), "w") as f:
+        with open(os.path.join(keyrings_dir, "default.keyring"), "wb") as f:
             f.write("[keyring]\n"
                     "display-name=default\n"
                     "lock-on-idle=false\n"

--- a/scripts/tweak-xwrapper
+++ b/scripts/tweak-xwrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -u
+#!/usr/bin/python3 -u
 
 # Copyright (C) 2013, Daniel Narvaez
 #
@@ -18,11 +18,11 @@
 
 config_path = "/etc/X11/Xwrapper.config"
 
-with open(config_path) as f:
+with open(config_path, 'rb') as f:
     new_config = [line for line in f.readlines()
                   if "allowed_users" not in line]
 
 new_config.append("allowed_users=anybody\n")
 
-with open(config_path, "w") as f:
+with open(config_path, "wb") as f:
     f.write("".join(new_config))

--- a/scripts/xephyr-window
+++ b/scripts/xephyr-window
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -u
+#!/usr/bin/python3 -u
 
 # Copyright (C) 2013, Daniel Narvaez
 #
@@ -40,5 +40,5 @@ SugarRunner.window_create(int(width), int(height), fullscreen)
 while SugarRunner.window_wait():
     if not fullscreen or SugarRunner.window_is_fullscreen():
         if not xid_printed:
-            print SugarRunner.window_get_xid()
+            print (SugarRunner.window_get_xid())
             xid_printed = True

--- a/scripts/xinitrc
+++ b/scripts/xinitrc
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 # Copyright (C) 2013, Daniel Narvaez
 #
@@ -48,7 +48,7 @@ def _load_xkb_config():
     if "SUGAR_RUNNER_XKBCONFIG" not in os.environ:
         return
 
-    with open(os.environ["SUGAR_RUNNER_XKBCONFIG"]) as f:
+    with open(os.environ["SUGAR_RUNNER_XKBCONFIG"], 'rb') as f:
         config = f.read()
 
     process = subprocess.Popen(["xkbcomp", "-", os.environ["DISPLAY"]],
@@ -65,14 +65,14 @@ def _add_output_to_environ(output):
 
 def _start_dbus():
     output = subprocess.check_output(["dbus-launch", "--exit-with-session"])
-    _add_output_to_environ(output)
+    _add_output_to_environ(output.decode())
 
 
 def _start_keyring():
     output = subprocess.check_output(["gnome-keyring-daemon",
                                       "--start", "-d",
                                       "--components=secrets,pkcs11,ssh,gpg"])
-    _add_output_to_environ(output)
+    _add_output_to_environ(output.decode())
 
 
 def _setup_xdg_user_dirs():


### PR DESCRIPTION
sugar-runner now works on the latest Fedora, but you need to be using Xorg, not Wayland. See README.md.